### PR TITLE
[fix bug] Ignore Server IP

### DIFF
--- a/src/ddos.sh
+++ b/src/ddos.sh
@@ -192,7 +192,7 @@ ban_incoming_and_outgoing()
         # Strip port without affecting ipv6 addresses (experimental)
         sed 's/:[0-9+]*$//g' | \
         # Ignore Server IP
-        sed -r "/($SERVER_IP_LIST)/Id" | \
+        sed -r "/^($SERVER_IP_LIST)$/Id" | \
         # Sort addresses for uniq to work correctly
         sort | \
         # Group same occurrences of ip and prepend amount of occurences found
@@ -244,7 +244,7 @@ ban_only_incoming()
         # Strip port without affecting ipv6 addresses (experimental)
         sed "s/:[0-9+]*$//g" | \
         # Ignore Server IP
-        sed -r "/($SERVER_IP_LIST)/Id" | \
+        sed -r "/^($SERVER_IP_LIST)$/Id" | \
         # Sort addresses for uniq to work correctly
         sort | \
         # Group same occurrences of ip and prepend amount of occurences found


### PR DESCRIPTION
In this case:
SERVER_IP_LIST=192.168.7.16|127.0.0.1

Pay attention to `192.168.7.16`:
When the IP should be baned like : `192.168.7.162`.

The ignore line `sed -r "/($SERVER_IP_LIST)/Id"` will match `192.168.7.162` as local server ip `192.168.7.16`, 
and ignore `192.168.7.162` which should be baned.