### PR TITLE
Replace path for systemd to /lib/systemd/system which always exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -118,11 +118,11 @@ fi
 
 echo;
 
-if [ -d /usr/lib/systemd/system ]; then
+if [ -d /lib/systemd/system ]; then
     echo -n 'Setting up systemd service...'
-    mkdir -p "$DESTDIR/usr/lib/systemd/system/"
-    cp src/ddos.service "$DESTDIR/usr/lib/systemd/system/" > /dev/null 2>&1
-    chmod 0755 "$DESTDIR/usr/lib/systemd/system/ddos.service" > /dev/null 2>&1
+    mkdir -p "$DESTDIR/lib/systemd/system/"
+    cp src/ddos.service "$DESTDIR/lib/systemd/system/" > /dev/null 2>&1
+    chmod 0755 "$DESTDIR/lib/systemd/system/ddos.service" > /dev/null 2>&1
     echo " (done)"
 
     # Check if systemctl is installed and activate service

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -25,14 +25,14 @@ if [ -e '/etc/rc.d/ddos' ]; then
     echo " (done)"
 fi
 
-if [ -e '/usr/lib/systemd/system/ddos.service' ]; then
+if [ -e '/lib/systemd/system/ddos.service' ]; then
     echo; echo -n "Deleting systemd service..."
     SYSTEMCTL_PATH=`whereis update-rc.d`
     if [ "$SYSTEMCTL_PATH" != "systemctl:" ]; then
         systemctl stop ddos > /dev/null 2>&1
         systemctl disable ddos > /dev/null 2>&1
     fi
-    rm -f /usr/lib/systemd/system/ddos.service
+    rm -f /lib/systemd/system/ddos.service
     echo -n ".."
     echo " (done)"
 fi


### PR DESCRIPTION
For the moment, the path checked for SystemD is /usr/lib/systemd/system.
I installed ddos-deflate on 4 different installations, this path existed only on one.
It looks like more frequent to use /lib/systemd/system for SystemD services.
That why I propose this pull request to modify install.sh and uninstall.sh to use /lib/systemd/system instead of /usr/lib/systemd/system.