### PR TITLE
Check if root before install or uninstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# Check if the script is executed as root
+if [ "$(id -u)" -ne 0 ]
+then
+echo "Please execute this script as root."
+exit 1
+fi
+
 # Check for required dependencies
 if [ -f "/usr/bin/apt-get" ]; then
     install_type='2';

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# Check if the script is executed as root
+if [ "$(id -u)" -ne 0 ]
+then
+echo "Please execute this script as root."
+exit 1
+fi
+
 clear
 
 echo "Uninstalling DOS-Deflate"


### PR DESCRIPTION
Root privileges are required to install or uninstall DDOS-deflate.
During this modification, a question came to my attention: why using Dash instead of Bash?
Because we cannot use $EUID nor $UID in Dash, id -u looks like to make the job right.